### PR TITLE
[BE] ✨ USER 서비스, 컨트롤러 CRUD 추가

### DIFF
--- a/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/domain/user/controller/UserController.java
+++ b/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/domain/user/controller/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/users")
@@ -32,8 +33,8 @@ public class UserController {
 
     // 유저 사진 등록
     @PostMapping("/{user-id}/image")
-    public ResponseEntity postUserImage(@Valid @RequestBody UserProfileImageDto userProfileImageDto) {
-
+    public ResponseEntity postUserImage(@PathVariable("user-id") Long userId, @Valid @RequestBody UserProfileImageDto userProfileImageDto) {
+        userService.updateProfileImage(userId, userProfileImageDto.getProfileImage());
         return new ResponseEntity(HttpStatus.OK);
     }
 
@@ -47,19 +48,20 @@ public class UserController {
 
     // 유저 사진 수정
     @PatchMapping("/{user-id}/image")
-    public ResponseEntity patchUserImage(@Valid @RequestBody UserProfileImageDto userProfileImageDto) {
-
+    public ResponseEntity patchUserImage(@PathVariable("user-id") Long userId, @Valid @RequestBody UserProfileImageDto userProfileImageDto) {
+        userService.updateProfileImage(userId, userProfileImageDto.getProfileImage());
         return new ResponseEntity(HttpStatus.OK);
     }
 
     // 유저 사진 삭제도 있어야 할 듯
 
-    // 유저 이름 수정
+
+    // 유저 정보 수정
     // 유저 정보 수정DTO에 수정할 정보 여러개 넣고 필요한 값만 받아 바꾸면 됨
     @PatchMapping("/{user-id}")
-    public ResponseEntity patchUserName(@Valid @RequestBody UserNamePatchDto userNamePatchDto) {
-
-        return new ResponseEntity(HttpStatus.OK);
+    public ResponseEntity patchUser(@Valid @RequestBody UserPatchDto userPatchDto, @PathVariable("user-id") Long userId) {
+        Users updateUser = userService.updateUser(userId, mapper.userPatchDtoToUser(userPatchDto));
+        return new ResponseEntity(mapper.userToUserResponseDto(updateUser), HttpStatus.OK);
     }
 
     // 특정 유저의 전체 게시글 가져오기
@@ -79,14 +81,14 @@ public class UserController {
     // 모든 유저 정보 가져오기
     @GetMapping
     public ResponseEntity getAllUserInfo() {
-
-        return new ResponseEntity(HttpStatus.OK);
+        List<Users> users = userService.findAllUser();
+        return new ResponseEntity(users, HttpStatus.OK);
     }
 
     // 특정 유저 삭제
     @DeleteMapping("/{user-id}")
-    public ResponseEntity deleteUser() {
-
+    public ResponseEntity deleteUser(@PathVariable("user-id") long userId) {
+        userService.deleteUser(userId);
         return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/domain/user/dto/UserPatchDto.java
+++ b/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/domain/user/dto/UserPatchDto.java
@@ -1,7 +1,10 @@
 package com.mainproject.grilledshrimp.domain.user.dto;
 
+import lombok.Getter;
+
+@Getter
 public class UserPatchDto {
     private String password;
     private String profile_image;
-    private String user_name;
+    private String username;
 }

--- a/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/domain/user/dto/UserProfileImageDto.java
+++ b/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/domain/user/dto/UserProfileImageDto.java
@@ -1,5 +1,8 @@
 package com.mainproject.grilledshrimp.domain.user.dto;
 
-public class UserProfileImageDto {
+import lombok.Getter;
 
+@Getter
+public class UserProfileImageDto {
+    private String profileImage;
 }

--- a/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/domain/user/mapper/UserMapper.java
+++ b/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/domain/user/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package com.mainproject.grilledshrimp.domain.user.mapper;
 
+import com.mainproject.grilledshrimp.domain.user.dto.UserPatchDto;
 import com.mainproject.grilledshrimp.domain.user.dto.UserPostDto;
 import com.mainproject.grilledshrimp.domain.user.dto.UserResponseDto;
 import com.mainproject.grilledshrimp.domain.user.entity.Users;
@@ -10,6 +11,7 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface UserMapper {
     Users userPostDtoToUser(UserPostDto userPostDto);
+    Users userPatchDtoToUser(UserPatchDto userPatchDto);
     UserResponseDto userToUserResponseDto(Users users);
     List<UserResponseDto> usersToUserResponseDtos(List<Users> users);
 }

--- a/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/global/image/controller/AmazonS3Controller.java
+++ b/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/global/image/controller/AmazonS3Controller.java
@@ -1,42 +1,42 @@
-package com.mainproject.grilledshrimp.global.image.controller;
-
-import com.mainproject.grilledshrimp.global.image.service.AwsS3Service;
-import lombok.RequiredArgsConstructor;
-import org.springframework.core.io.Resource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.core.io.UrlResource;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.net.MalformedURLException;
-import java.util.List;
-
-@RestController
-@RequiredArgsConstructor
-@RequestMapping("/s3")
-public class AmazonS3Controller {
-
-    private final AwsS3Service awsS3Service;
-
-    /**
-     * Amazon S3에 파일 업로드
-     * @return 성공 시 201 CREATED 와 함께 업로드 된 파일의 파일명 리스트 반환
-     */
-    @PostMapping("/file")
-    public ResponseEntity<List<String>> uploadFile(@RequestPart List<MultipartFile> multipartFile) {
-        return new ResponseEntity<>(awsS3Service.uploadImage(multipartFile), HttpStatus.CREATED);
-    }
-
-    /**
-     * Amazon S3에 업로드 된 파일을 삭제
-     * @return 성공 시 204 NO_CONTENT 반환
-     */
-    @DeleteMapping("/file")
-    public ResponseEntity<Void> deleteFile(@RequestParam String fileName) {
-        awsS3Service.deleteImage(fileName);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-    }
-}
+//package com.mainproject.grilledshrimp.global.image.controller;
+//
+//import com.mainproject.grilledshrimp.global.image.service.AwsS3Service;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.core.io.Resource;
+//import org.springframework.http.HttpHeaders;
+//import org.springframework.core.io.UrlResource;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.MediaType;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//import org.springframework.web.multipart.MultipartFile;
+//
+//import java.net.MalformedURLException;
+//import java.util.List;
+//
+//@RestController
+//@RequiredArgsConstructor
+//@RequestMapping("/s3")
+//public class AmazonS3Controller {
+//
+//    private final AwsS3Service awsS3Service;
+//
+//    /**
+//     * Amazon S3에 파일 업로드
+//     * @return 성공 시 201 CREATED 와 함께 업로드 된 파일의 파일명 리스트 반환
+//     */
+//    @PostMapping("/file")
+//    public ResponseEntity<List<String>> uploadFile(@RequestPart List<MultipartFile> multipartFile) {
+//        return new ResponseEntity<>(awsS3Service.uploadImage(multipartFile), HttpStatus.CREATED);
+//    }
+//
+//    /**
+//     * Amazon S3에 업로드 된 파일을 삭제
+//     * @return 성공 시 204 NO_CONTENT 반환
+//     */
+//    @DeleteMapping("/file")
+//    public ResponseEntity<Void> deleteFile(@RequestParam String fileName) {
+//        awsS3Service.deleteImage(fileName);
+//        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+//    }
+//}

--- a/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/global/image/service/AwsS3Service.java
+++ b/server/grilledshrimp/src/main/java/com/mainproject/grilledshrimp/global/image/service/AwsS3Service.java
@@ -1,70 +1,70 @@
-package com.mainproject.grilledshrimp.global.image.service;
-
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.*;
-import com.mainproject.grilledshrimp.global.exception.BusinessLogicException;
-import com.mainproject.grilledshrimp.global.exception.ExceptionCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.InputStreamResource;
-import org.springframework.core.io.Resource;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
-@Service
-@RequiredArgsConstructor
-public class AwsS3Service {
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
-    private final AmazonS3 amazonS3;
-
-    public List<String> uploadImage(List<MultipartFile> multipartFile) {
-        List<String> fileNameList = new ArrayList<>();
-
-        // forEach 구문을 통해 multipartFile로 넘어온 파일들 하나씩 fileNameList에 추가
-        multipartFile.forEach(file -> {
-            String fileName = "images/" + createFileName(file.getOriginalFilename());
-            ObjectMetadata objectMetadata = new ObjectMetadata();
-            objectMetadata.setContentLength(file.getSize());
-            objectMetadata.setContentType(file.getContentType());
-
-            try(InputStream inputStream = file.getInputStream()) {
-                amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
-                        .withCannedAcl(CannedAccessControlList.PublicRead));
-            } catch(IOException e) {
-                throw new BusinessLogicException(ExceptionCode.IMAGE_UPLOAD_FAILED);
-            }
-
-            fileNameList.add(fileName);
-        });
-
-        return fileNameList;
-    }
-
-
-    public void deleteImage(String fileName) {
-        amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
-    }
-
-    private String createFileName(String fileName) { // 먼저 파일 업로드 시, 파일명을 난수화하기 위해 random으로 돌립니다.
-        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
-    }
-
-    private String getFileExtension(String fileName) { // file 형식이 잘못된 경우를 확인하기 위해 만들어진 로직이며, 파일 타입과 상관없이 업로드할 수 있게 하기 위해 .의 존재 유무만 판단하였습니다.
-        try {
-            return fileName.substring(fileName.lastIndexOf("."));
-        } catch (StringIndexOutOfBoundsException e) {
-            throw new BusinessLogicException(ExceptionCode.ILLIGAL_IMAGE_TYPE);
-        }
-    }
-}
+//package com.mainproject.grilledshrimp.global.image.service;
+//
+//import com.amazonaws.services.s3.AmazonS3;
+//import com.amazonaws.services.s3.model.*;
+//import com.mainproject.grilledshrimp.global.exception.BusinessLogicException;
+//import com.mainproject.grilledshrimp.global.exception.ExceptionCode;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.core.io.InputStreamResource;
+//import org.springframework.core.io.Resource;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.stereotype.Service;
+//import org.springframework.web.multipart.MultipartFile;
+//import org.springframework.web.server.ResponseStatusException;
+//
+//import java.io.IOException;
+//import java.io.InputStream;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.UUID;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class AwsS3Service {
+//
+//    @Value("${cloud.aws.s3.bucket}")
+//    private String bucket;
+//
+//    private final AmazonS3 amazonS3;
+//
+//    public List<String> uploadImage(List<MultipartFile> multipartFile) {
+//        List<String> fileNameList = new ArrayList<>();
+//
+//        // forEach 구문을 통해 multipartFile로 넘어온 파일들 하나씩 fileNameList에 추가
+//        multipartFile.forEach(file -> {
+//            String fileName = "images/" + createFileName(file.getOriginalFilename());
+//            ObjectMetadata objectMetadata = new ObjectMetadata();
+//            objectMetadata.setContentLength(file.getSize());
+//            objectMetadata.setContentType(file.getContentType());
+//
+//            try(InputStream inputStream = file.getInputStream()) {
+//                amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+//                        .withCannedAcl(CannedAccessControlList.PublicRead));
+//            } catch(IOException e) {
+//                throw new BusinessLogicException(ExceptionCode.IMAGE_UPLOAD_FAILED);
+//            }
+//
+//            fileNameList.add(fileName);
+//        });
+//
+//        return fileNameList;
+//    }
+//
+//
+//    public void deleteImage(String fileName) {
+//        amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+//    }
+//
+//    private String createFileName(String fileName) { // 먼저 파일 업로드 시, 파일명을 난수화하기 위해 random으로 돌립니다.
+//        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+//    }
+//
+//    private String getFileExtension(String fileName) { // file 형식이 잘못된 경우를 확인하기 위해 만들어진 로직이며, 파일 타입과 상관없이 업로드할 수 있게 하기 위해 .의 존재 유무만 판단하였습니다.
+//        try {
+//            return fileName.substring(fileName.lastIndexOf("."));
+//        } catch (StringIndexOutOfBoundsException e) {
+//            throw new BusinessLogicException(ExceptionCode.ILLIGAL_IMAGE_TYPE);
+//        }
+//    }
+//}


### PR DESCRIPTION
## 이슈번호
#33 #31 #30 

## 개요
유저 정보 수정, 유저 프로필 이미지 추가, 특정 유저 조회, 특정 유저 삭제 서비스 추가 하였습니다.

## 작업사항
### UserController
- postUserImage
- patchUserImage
- patchUser
- getUserInfo
- getAllUserInfo
- deleteUser
각 메소드의 로직이 추가되었습니다.

### UserService
- findUser
  - 특정 유저를 찾습니다.
- findAllUser
  - 모든 유저를 찾습니다.
- updateProfileImage
  - 유저의 프로필 이미지를 수정합니다.
- updateUser
  - 유저의 정보를 수정합니다.
- deleteUser
  - 특정 유저를 삭제합니다.

## 변경로직
- 유저 정보를 수정하는 로직에서 각 필드에 해당하는 patchDto를 따로 생성하지 않습니다. 
- UserPatchDto에 수정할 수 있는 모든 필드를 넣고 FE로 부터 수정하고 싶은 필드만 받아 수정 할 수 있도록 하였습니다. 
- 추후 예정 -> UserProfileImageDto, UserPasswordPatchDto, UserNamePatchDto 클래스를 삭제해도 될 것 같습니다.
